### PR TITLE
Add a prelim task to query microsoft ATP

### DIFF
--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -221,8 +221,8 @@ module Api
       begin 
         parsed_results = JSON.parse(results.body)
         out.merge!({status: "success", results: parsed_results })
-      rescue
-        out.merge!({status: "fail", message: "error parsing", results: {} })
+      rescue => e 
+        out.merge!({status: "fail", message: "error parsing: #{e}", results: {} })
       end
 
     out 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -106,7 +106,6 @@ module Kenna
           end
         end
       end
-
       
     end
   end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -1,0 +1,74 @@
+module Kenna
+  module Toolkit
+    module Helpers
+      module Http
+      
+      def http_get(url, headers, max_retries=5)
+        begin
+          RestClient::Request.execute(
+            method: :get,
+            url: url,
+            headers: headers
+          )
+        rescue RestClient::TooManyRequests =>e
+          puts "Exception! #{e}" 
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            sleep(15)
+            puts "Retrying!"
+            retry
+          end
+        rescue RestClient::UnprocessableEntity => e
+          puts "Exception! #{e}" 
+        rescue RestClient::BadRequest => e
+          puts "Exception! #{e}" 
+        rescue RestClient::Exception => e
+          puts "Exception! #{e}" 
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            sleep(15)
+            puts "Retrying!"
+            retry
+          end
+        end
+      end
+
+      def http_post(url, headers, payload, max_retries=5)
+        begin
+          RestClient::Request.execute(
+            method: :post,
+            url: url,
+            payload: payload,
+            headers: headers
+          )
+        rescue RestClient::TooManyRequests =>e
+          puts "Exception! #{e}" 
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
+            retry
+          end
+        rescue RestClient::UnprocessableEntity => e
+          puts "Exception! #{e}" 
+        rescue RestClient::BadRequest => e
+          puts "Exception! #{e}" 
+        rescue RestClient::Exception => e
+          puts "Exception! #{e}" 
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
+            retry
+          end
+        end
+      end
+
+    end
+  end
+end
+end

--- a/lib/kdi/kdi_helpers.rb
+++ b/lib/kdi/kdi_helpers.rb
@@ -3,6 +3,11 @@ module Toolkit
 
 	module KdiHelpers
 
+		def kdi_initialize
+			@assets = []
+			@vuln_defs = []
+		end
+
 		def uniq(a)
 			{
 			 	"file": a["file"],
@@ -45,7 +50,7 @@ module Toolkit
 	  #  }
 	  #
 	  def create_kdi_asset(asset_hash)
-	    raise "Unable to detect assets array! Did you create one called '@assets'? " unless @assets
+	    kdi_initialize unless @assets
 
 	    # if we already have it, skip ... do this by selecting based on our dedupe field
 	    # and making sure we don't already have it
@@ -81,7 +86,7 @@ module Toolkit
 	  #  port: integer
 	  # }
 	  def create_kdi_asset_vuln(asset_hash, vuln_hash)
-	    raise "Unable to detect assets array! Did you create one called '@assets'? " unless @assets
+	    kdi_initialize unless @assets
 
 	    # check to make sure it doesnt exist
 			a = @assets.select{|a| uniq(a) == uniq(asset_hash) }.first
@@ -119,8 +124,8 @@ module Toolkit
 	  #   solution: string, (steps or links for remediation teams)
 	  # }
 		def create_kdi_vuln_def(vuln_def)
+			kdi_initialize unless @vuln_defs
 			
-	    raise "Unable to detect vuln defs array! Did you create one called '@vuln_defs'? " unless @vuln_defs
 			return unless @vuln_defs.select{|vd| vd["scanner_identifier"] == vuln_def["scanner_identifier"] }.empty?
 
 	    @vuln_defs << vuln_def

--- a/lib/toolkit.rb
+++ b/lib/toolkit.rb
@@ -9,7 +9,9 @@ require_relative '../initialize/string'
 
 # local deps
 require_relative 'helpers'
+require_relative 'http'
 include Kenna::Toolkit::Helpers
+include Kenna::Toolkit::Helpers::Http
 
 # Shared libraries / mapping / data etc
 require_relative 'data/mapping/digi_footprint_finding_mapper'

--- a/tasks/microsoft_atp/lib/microsoft_atp_helper.rb
+++ b/tasks/microsoft_atp/lib/microsoft_atp_helper.rb
@@ -1,0 +1,67 @@
+
+module Kenna
+module Toolkit
+module MicrosoftAtpHelper
+
+  def atp_get_machines(token)
+    print "Getting machines"
+    headers = {'Content-Type' => 'application/json', 'Accept' => 'application/json', 'Authorization' => "Bearer #{token}", 'accept-encoding' => 'identity'}
+    url = "https://api.securitycenter.microsoft.com/api/machines"
+    
+    response = http_get(url, headers)
+    return nil unless response 
+
+    begin 
+      json = JSON.parse(response.body)
+    rescue JSON::ParserError => e 
+      print_error "Unable to process response!"
+    end
+
+  json["value"]
+  end
+  
+  def atp_get_vulns(token,machine_id)
+    print "Getting vulns for machine #{machine_id}"
+    atp_query_api = "https://api.securitycenter.microsoft.com/"
+    headers = {'content-type' => 'application/json', 'accept' => 'application/json', 'Authorization' => "Bearer #{token}", 'accept-encoding' => 'identity'}
+    url =  "#{atp_query_api}/api/machines/#{machine_id}/vulnerabilities"
+    
+    response = http_get(url, headers)
+    return nil unless response 
+    
+    begin 
+      json = JSON.parse(response.body)
+    rescue JSON::ParserError => e 
+      print_error "Unable to process response!"
+    end
+
+  json["value"]
+  end
+ 
+  def atp_get_auth_token(tenant_id, client_id,secret)
+    print "Getting token"
+    atp_query_api = "https://api.securitycenter.microsoft.com/"
+    oauth_url = "https://login.windows.net/#{tenant_id}/oauth2/token"
+    headers = {'content-type' =>  'application/x-www-form-urlencoded'}
+    mypayload = {
+      "resource" => atp_query_api, 
+      "client_id" => "#{client_id}", 
+      "client_secret" => "#{secret}", 
+      "grant_type" => "client_credentials"
+    }
+
+    response = http_post(oauth_url, headers, mypayload)
+    return nil unless response 
+
+    begin 
+      json = JSON.parse(response.body)
+    rescue JSON::ParserError => e 
+      print_error "Unable to process response!"
+    end
+
+  json.fetch("access_token")
+  end
+
+end
+end
+end

--- a/tasks/microsoft_atp/microsoft_atp.rb
+++ b/tasks/microsoft_atp/microsoft_atp.rb
@@ -1,0 +1,153 @@
+require_relative "lib/microsoft_atp_helper"
+
+module Kenna 
+module Toolkit
+class MicrosoftAtp < Kenna::Toolkit::BaseTask
+
+  include Kenna::Toolkit::MicrosoftAtpHelper
+
+  def self.metadata 
+    {
+      id: "microsoft_atp",
+      name: "Microsoft ATP",
+      description: "Pulls assets and vulnerabilitiies from Microsoft ATP",
+      options: [
+        {:name => "atp_tenant_id", 
+          :type => "strign", 
+          :required => true, 
+          :default => nil, 
+          :description => "Microsoft ATP Tenant ID" },
+        {:name => "atp_client_id", 
+          :type => "api_key", 
+          :required => true, 
+          :default => nil, 
+          :description => "Microsoft ATP Client ID" },
+        {:name => "atp_client_secret", 
+          :type => "api_key", 
+          :required => true, 
+          :default => nil, 
+          :description => "Microsoft ATP Client Secret" },
+        {:name => "kenna_api_token", 
+          :type => "api_key", 
+          :required => false, 
+          :default => nil, 
+          :description => "Kenna API Key" },
+        {:name => "kenna_api_host", 
+          :type => "hostname", 
+          :required => false  , 
+          :default => "api.kennasecurity.com", 
+          :description => "Kenna API Hostname" }, 
+        { :name => "kenna_connector_id", 
+          :type => "integer", 
+          :required => false, 
+          :default => nil, 
+          :description => "If set, we'll try to upload to this connector"  },    
+        { :name => "output_directory", 
+          :type => "filename", 
+          :required => false, 
+          :default => "output/microsoft_atp", 
+          :description => "If set, will write a file upon completion. Path is relative to #{$basedir}"  }
+      ]
+    }
+  end
+
+  def run(opts)
+    super # opts -> @options
+
+    atp_tenant_id = @options[:atp_tenant_id]
+    atp_client_id = @options[:atp_client_id]
+    atp_client_secret = @options[:atp_client_secret]
+    
+    kenna_api_host = @options[:kenna_api_host]
+    kenna_api_token = @options[:kenna_api_token]
+    kenna_connector_id = @options[:kenna_connector_id]
+    
+    token = atp_get_auth_token(atp_tenant_id, atp_client_id, atp_client_secret)
+    machine_json = atp_get_machines(token)
+
+    machine_json.each do |machine| 
+      
+      machine_id = machine.fetch("id")
+
+      # Save these to persist on the vuln
+      first_seen = machine.fetch("firstSeen")
+      last_seen = machine.fetch("lastSeen")
+
+      # Get the asset details & craft them into a hash
+      asset = { 
+        "hostname" =>  machine.fetch("computerDnsName"),
+        "ip_address" => machine.fetch("lastIpAddress"),
+        "external_id" => machine_id,
+        "os" => machine.fetch("osPlatform"),
+        "os_version" => machine.fetch("osVersion"),
+        "first_seen" => machine.fetch("firstSeen"), # TODO ... this doesnt exist on the asset today, but won't hurt here.
+        "last_seen" => machine.fetch("lastSeen") # TODO ... this doesnt exist on the asset today
+      }
+
+      # Construct tags
+      tags = []
+      tags << "riskScore: #{machine.fetch('riskScore')}" unless machine.fetch("riskScore").nil?
+      tags << "exposureLevel: #{machine.fetch('exposureLevel')}" unless machine.fetch("exposureLevel").nil?
+      tags << "MSATP Agent Version: #{machine.fetch('agentVersion')}" unless machine.fetch("agentVersion").nil?
+      tags.concat(machine.fetch("machineTags")) unless machine.fetch("machineTags").nil?
+      
+      # Add them to our asset hash
+      asset.merge({"tags" => tags})
+      create_kdi_asset(asset)
+
+      # now get the vulns 
+      vuln_json = atp_get_vulns(token, machine.fetch("id"))
+      vuln_severity = { "Critical" => 10, "High" => 8, "Medium" => 6, "Low" => 3} # converter
+      vuln_json.each do |vuln|
+
+        #print JSON.pretty_generate vuln
+        
+        vuln_id = vuln.fetch("id")
+        vuln_name = vuln.fetch("name")
+        vuln_description = vuln.fetch("description")
+        vuln_score = vuln["cvssV3"] || vuln_severity[vuln.fetch("severity")]
+
+        # craft the vuln hash
+        vuln = {
+          "scanner_identifier" => vuln_id,
+          "scanner_type" => "MSATP",
+          "name" => vuln_name,
+          # scanner score should fallback using criticality (in case of missing cvss)
+          "scanner_score" => vuln_score, 
+          "last_seen_at" => last_seen
+        }
+
+        # craft the vuln def hash
+        vuln_def= {
+          "scanner_identifier" => vuln_id,
+          "name" => vuln_name,
+          "scanner_type" => "MSATP",
+          "description" => vuln_description
+        }
+
+        # Create the KDI entries 
+        create_kdi_asset_vuln(asset, vuln)
+        create_kdi_vuln_def(vuln_def)
+      end
+
+    end
+
+    ### Write KDI format
+    kdi_output = { skip_autoclose: false, assets: @assets, vuln_defs: @vuln_defs }
+    output_dir = "#{$basedir}/#{@options[:output_directory]}"
+    filename = "microsoft_atp.kdi.json"
+    write_file output_dir, filename, JSON.pretty_generate(kdi_output)
+    print_good "Output is available at: #{output_dir}/#{filename}"
+
+    ### Finish by uploading if we're all configured
+    if kenna_connector_id && kenna_api_host && kenna_api_token
+      print_good "Attempting to upload to Kenna API at #{kenna_api_host}"
+      upload_file_to_kenna_connector kenna_connector_id, kenna_api_host, kenna_api_token, "#{output_dir}/#{filename}"
+    end
+
+  end
+
+
+end
+end
+end


### PR DESCRIPTION
All kudos to @lindambrown for building this, this is just a cleanup pass on her original script.

Note that this does not yet handle pagination and is only tested with a very small set of data. That said, is working against the ATP apis now: 


```
jcran toolkit develop [20200605]$ cat /bundle exec ruby ./toolkit.rb task=microsoft_atp:atp_tenant_id=$ATP_TENANT_ID:atp_client_id=$ATP_CLIENT_ID:atp_client_secret=$ATP_SECRET
Running: Kenna::Toolkit::MicrosoftAtp
[+] (20200605104607) Setting kenna_api_host to default value: api.kennasecurity.com
[+] (20200605104607) Setting output_directory to default value: output/microsoft_atp
[+] (20200605104607) Got option: task: microsoft_atp
[+] (20200605104607) Got option: atp_tenant_id: 5******903
[+] (20200605104607) Got option: atp_client_id: 5*****095
[+] (20200605104607) Got option: atp_client_secret: 7*******fS-
[+] (20200605104607) Got option: kenna_api_host: api.kennasecurity.com
[+] (20200605104607) Got option: kenna_connector_id: 
[+] (20200605104607) Got option: output_directory: output/microsoft_atp
[+] (20200605104607) 
[+] (20200605104607) Launching the Microsoft ATP task!
[+] (20200605104607) 
[ ] (20200605104607) Getting token
[ ] (20200605104607) Getting machines
[ ] (20200605104608) Getting vulns for machine 33f60faf29219b8df28a31acfe53d1519d736a8a
[ ] (20200605104610) Getting vulns for machine 17cb73b0890dbdeddc06a18e516e4327572d9442
[+] (20200605104610) Output is available at: /Users/jcran/work/kennasecurity/local/toolkit/output/microsoft_atp/microsoft_atp.kdi.json
```