### PR TITLE
Expanse: Properly split cloud_exposure_types into array

### DIFF
--- a/tasks/expanse/lib/mapper.rb
+++ b/tasks/expanse/lib/mapper.rb
@@ -122,7 +122,7 @@ module Mapper
     ### Get the list of exposure types
     ###
     if @options && @options[:cloud_exposure_types]
-      cloud_exposure_types = "#{@options[:cloud_exposure_types]}".downcase.gsub("-","_")
+      cloud_exposure_types = "#{@options[:cloud_exposure_types]}".downcase.gsub('-','_').split(',')
     else
       cloud_exposure_counts = @client.cloud_exposure_counts
       puts "Got Cloud Exposure Counts: #{cloud_exposure_counts}"


### PR DESCRIPTION
This had issues when cloud_exposure_types is explicitly provided as an arg.  Excellent details on this issue provided by @andrew-expanse in #39.


Fixes #39