### PR TITLE
Remove node js 10 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ RUN mkdir -p ${TOOLKIT_HOME}
 RUN groupadd -g "${TOOLKIT_GID}" "${TOOLKIT_USER}" && \
     adduser -u "${TOOLKIT_UID}" -g "${TOOLKIT_GID}" -d "${TOOLKIT_HOME}" "${TOOLKIT_USER}"
 
-RUN chown -R "${TOOLKIT_UID}":"${TOOLKIT_GID}" "${TOOLKIT_HOME}"
+RUN chown -R "${TOOLKIT_USER}" "${TOOLKIT_HOME}"
 
 # set up gem env
 ENV BUNDLER_VERSION=2.0.2
@@ -21,11 +21,11 @@ RUN gem install bundler:"${BUNDLER_VERSION}"
 ENV GEM_HOME=/opt/app/bundle/
 ENV BUNDLE_SILENCE_ROOT_WARNING=1 BUNDLE_APP_CONFIG="${GEM_HOME}"
 ENV PATH "${GEM_HOME}"/bin:$PATH
-RUN mkdir -p "${GEM_HOME}" && chown -R "${TOOLKIT_UID}":"${TOOLKIT_GID}" "${GEM_HOME}"
+RUN mkdir -p "${GEM_HOME}" && chown -R "${TOOLKIT_USER}" "${GEM_HOME}"
 
 # add our files, ensure we can write to output
 ADD . "${TOOLKIT_HOME}"
-RUN chown -R "${TOOLKIT_UID}":"${TOOLKIT_GID}" "${TOOLKIT_HOME}/output"
+RUN chown -R "${TOOLKIT_USER}" "${TOOLKIT_HOME}output"
 
 # install deps 
 WORKDIR "${TOOLKIT_HOME}"

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,9 @@ ENV TOOLKIT_HOME=/opt/app/toolkit/
 ENV TOOLKIT_UID=1000
 ENV TOOLKIT_USER=kenna
 
+# Removing NodeJS from base image since it isnt needed. (JG 10/25/2020)
+RUN yum remove -y nodejs 
+
 RUN mkdir -p ${TOOLKIT_HOME}
 
 RUN groupadd -g "${TOOLKIT_GID}" "${TOOLKIT_USER}" && \

--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ ENV BUNDLER_VERSION=2.0.2
 RUN gem install bundler:"${BUNDLER_VERSION}"
 ENV GEM_HOME=/opt/app/bundle/
 ENV BUNDLE_SILENCE_ROOT_WARNING=1 BUNDLE_APP_CONFIG="${GEM_HOME}"
-ENV PATH "${GEM_HOME}"/bin:$PATH
+ENV PATH "${GEM_HOME}"/bin:"$PATH"
 RUN mkdir -p "${GEM_HOME}" && chown -R "${TOOLKIT_USER}" "${GEM_HOME}"
 
 # add our files, ensure we can write to output
@@ -34,4 +34,4 @@ RUN bundle install
 
 ENTRYPOINT ["./scripts/entrypoint.sh"]
 
-CMD ['help']
+CMD ["help"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kennasecurity/ruby:2.6.3
+FROM quay.io/kennasecurity/ruby:2.6.3-ubi
 LABEL maintainer="Kenna Security"
 
 USER root


### PR DESCRIPTION
Removes NodeJS 10 from images since we don't need it and it has open CVEs. 