### PR TITLE
Added required annotation and default value to task specific help for tasks  (task=taskname:help)

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -62,6 +62,7 @@ module Kenna
         task = TaskManager.tasks.select{|x| x.metadata[:id] == task_name }.first.new
         task.class.metadata[:options].each do |o|
           puts "- Task Option: #{o[:name]} (#{o[:type]}): #{o[:description]}"
+          puts "               Required:(#{o[:required]}): Default: #{o[:default]}"
         end
       end
 


### PR DESCRIPTION
Added required annotation and default value to task specific help for tasks  (task=taskname:help)

This will provide more context for users to create command lines directly from their terminal without referencing the read.md