### PR TITLE
Temporarily downgrade rubocop to 0.82.0, to match super-linter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'json'
 gem 'rest-client'
 
 group :development, :test do
-  gem 'rubocop', require: false
+  gem 'rubocop', "~> 0.82.0", require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     json (2.3.0)
     method_source (0.9.2)
@@ -31,14 +32,13 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     netrc (0.11.0)
-    parallel (1.20.0)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
-    regexp_parser (1.8.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -58,17 +58,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (1.3.1)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.1)
-      parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
     unf (0.1.4)
       unf_ext
@@ -85,7 +82,7 @@ DEPENDENCIES
   pry
   rest-client
   rspec
-  rubocop
+  rubocop (~> 0.82.0)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This PR, unfortunately, downgrades rubocop from 1.3.1 to 0.82.0[1] (which dates to 2020-04-16). This will ensure that whether you get rubocop feedback locally via the command line or your editor, or remotely via our Github code linting action, you will get the same results.

In my view, there aren't any new "cops" introduced between 0.82.0 and 1.3.1 that are super important for our own needs, so I don't think this downgrade has a material impact on our linting.

Once the upstream super-linter project that powers our action supports a more recent version of rubocop, we can upgrade both that and rubocop in this repo in tandem.

Rubocop is 100% clean as of this PR, reporting no issues.

https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0820-2020-04-16
